### PR TITLE
Added two spaces at end of lines.

### DIFF
--- a/2019-01-31-All about-WebAssembly-in-your-Browser/README.md
+++ b/2019-01-31-All about-WebAssembly-in-your-Browser/README.md
@@ -6,19 +6,19 @@ Antonio talks WASM! WebAssembly (abbreviated Wasm) is a binary instruction forma
 
 ## Links Referenced
 
-https://idxbroker.com/
-https://hackforacause.org
-https://github.com/eugenewebdevs/workshops
+https://idxbroker.com/  
+https://hackforacause.org  
+https://github.com/eugenewebdevs/workshops  
 
-https://blog.sessionstack.com/how-javascript-works-a-comparison-with-webassembly-why-in-certain-cases-its-better-to-use-it-d80945172d79
-https://caniuse.com/#feat=wasm
-https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running
-https://www.funkykarts.rocks/demo.html
-https://www.rossis.red/wasm.html
-https://github.com/shamadee/web-dsp
-https://webassembly.org/docs/future-features/
+https://blog.sessionstack.com/how-javascript-works-a-comparison-with-webassembly-why-in-certain-cases-its-better-to-use-it-d80945172d79  
+https://caniuse.com/#feat=wasm  
+https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running  
+https://www.funkykarts.rocks/demo.html  
+https://www.rossis.red/wasm.html  
+https://github.com/shamadee/web-dsp  
+https://webassembly.org/docs/future-features/  
 
 
-https://arxiv.org/abs/1901.09056
-https://github.com/mbasso/awesome-wasm
+https://arxiv.org/abs/1901.09056  
+https://github.com/mbasso/awesome-wasm  
 


### PR DESCRIPTION
Links were all running together. I think Markdown wants two spaces at the end of a line to force a new line.
Also, @antonioortegajr, can you add the link to your slidedeck?